### PR TITLE
Fix reuse checkbox not being respected for enrichments

### DIFF
--- a/app.py
+++ b/app.py
@@ -1584,8 +1584,8 @@ async def extract_papers(session, login_link, conference, conference_name, outpu
         session.current_step = 'authors'
         session.log('Starting author enrichment...')
 
-        # Load existing enriched authors if not already loaded (for fresh extractions)
-        if not existing_enriched and os.path.exists(authors_file):
+        # Load existing enriched authors only if reuse is enabled
+        if reuse_existing and not existing_enriched and os.path.exists(authors_file):
             try:
                 with open(authors_file, 'r', encoding='utf-8') as f:
                     existing_authors = json.load(f)
@@ -1723,10 +1723,10 @@ async def extract_papers(session, login_link, conference, conference_name, outpu
         # Required fields for a complete paper enrichment
         PAPER_REQUIRED_FIELDS = ['key_findings', 'description', 'key_contribution', 'novelty', 'ai_categories']
 
-        # Load existing enriched papers if available
+        # Load existing enriched papers only if reuse is enabled
         existing_enriched_papers = {}
         existing_categories = []
-        if os.path.exists(papers_enrichment_file):
+        if reuse_existing and os.path.exists(papers_enrichment_file):
             try:
                 with open(papers_enrichment_file, 'r', encoding='utf-8') as f:
                     existing_data = json.load(f)


### PR DESCRIPTION
## Summary

When the reuse checkbox was unchecked, the app would still load and reuse existing author and paper enrichments from disk. This PR fixes that by only loading existing enrichments when `reuse_existing=True`.

## Changes

Two conditions were missing the `reuse_existing` check:
- Author enrichment (line 1588): now checks `reuse_existing and not existing_enriched and os.path.exists(...)`
- Paper enrichment (line 1729): now checks `reuse_existing and os.path.exists(...)`

## Test plan

- [ ] Uncheck "reuse" checkbox and run extraction - should re-enrich all authors and papers
- [ ] Check "reuse" checkbox and run extraction - should reuse existing enrichments

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)